### PR TITLE
adds archival note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+
+# This repository is superseded by the work at ToIP Technical Stack Working Group ACDC Task Force
+
+https://github.com/trustoverip/tswg-cesr-proof-specification
+
+
 # CESR Verifiable Credential Proof Format
 
 This is the working area for the individual Internet-Draft, "CESR Verifiable Credential Proof Format".


### PR DESCRIPTION
Due to the proposed move to the Trust over IP Foundation, we should archive this repository.